### PR TITLE
Random fix

### DIFF
--- a/examples/dictionary.cpp
+++ b/examples/dictionary.cpp
@@ -32,10 +32,10 @@ std::ostream &operator<<(std::ostream &out, const DictKey &o) {
 void foundit(skiplist<DictKey> &s, DictKey x) {
   skiplist<DictKey>::iterator itr = s.find(x);
   if (itr != std::end(s))
-    cout << "Value: " << itr.node->val << " Count: " << itr.node->count
+    std::cout << "Value: " << itr.node->val << " Count: " << itr.node->count
          << std::endl;
   else
-    cout << "Not found: " << x << "\n";
+    std::cout << "Not found: " << x << "\n";
 }
 
 int main() {

--- a/examples/iterator_test.cpp
+++ b/examples/iterator_test.cpp
@@ -4,10 +4,10 @@
 template<typename T>
 void display(T first, T last) {
     while(first != last) {
-        cout << *first << " ";
+      std::cout << *first << " ";
         ++first;
     }
-    cout << "\n";
+    std::cout << "\n";
 }
 
 int main() {
@@ -21,15 +21,15 @@ int main() {
     }
     visualize(iskip);
 
-    cout << "Forward iterator :\n";
+    std::cout << "Forward iterator :\n";
     display(iskip.begin(), iskip.end());
 
-    cout << "Reverse iterator:\n";
+    std::cout << "Reverse iterator:\n";
     display(iskip.rbegin(), iskip.rend());
 
-    cout << "Forward constant iterator :\n";
+    std::cout << "Forward constant iterator :\n";
     display(iskip.cbegin(), iskip.cend());
 
-    cout << "Reverse constant iterator:\n";
+    std::cout << "Reverse constant iterator:\n";
     display(iskip.crbegin(), iskip.crend());
 }

--- a/skiplist/skiplist.hpp
+++ b/skiplist/skiplist.hpp
@@ -6,15 +6,10 @@ Only the skiplist container should be visible
 #define SKIPLIST_H
 #include <vector>
 #include <map>
-#include <iomanip>
-#include <ctime>
 #include <random>
-using std::vector;
 
-// for debugging
+#include <iomanip>
 #include <iostream>
-using std::cout;
-using std::endl;
 
 template<typename T>
 class skiplist;
@@ -41,7 +36,7 @@ template<typename value_type>
 class skiplist {
 private:
     // header nodes for all levels
-    vector<SLNode<value_type>*> key;
+    std::vector<SLNode<value_type>*> key;
     // number of nodes in the skiplist (including non-unique ones)
     int size_;
     // the last node at level 0
@@ -383,7 +378,7 @@ void skiplist<T>::insert(T value) {
     // If not exists, create upper levels for that element
 
     // This is the prev nodes for all levels
-    vector<SLNode<T>*> history;
+    std::vector<SLNode<T>*> history;
     // Search always starts from the upper left node
     SLNode<T>* follow = key.back();
     // Go on till level 0


### PR DESCRIPTION
**To be merged after merging #2, don't merge now**

 - Replace use of `rand()` and `srand()` with things from the C++ random library. References: [[1]](https://en.cppreference.com/w/cpp/numeric/random), [[2]](https://stackoverflow.com/a/19666713/11199009)
 - Remove `using std::` statements in the header file that caused the namespaces to be used even in files where the header was included (it caused side-effects outside of what it's supposed to do).